### PR TITLE
Adds UserView

### DIFF
--- a/GitHubExplorer.xcodeproj/project.pbxproj
+++ b/GitHubExplorer.xcodeproj/project.pbxproj
@@ -1,0 +1,555 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		A24E3A2B2DE9C73900311DBF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A24E3A152DE9C73500311DBF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A24E3A1C2DE9C73500311DBF;
+			remoteInfo = GitHubExplorer;
+		};
+		A24E3A352DE9C73900311DBF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A24E3A152DE9C73500311DBF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A24E3A1C2DE9C73500311DBF;
+			remoteInfo = GitHubExplorer;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A24E3A1D2DE9C73500311DBF /* GitHubExplorer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitHubExplorer.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A24E3A2A2DE9C73900311DBF /* GitHubExplorerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitHubExplorerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A24E3A342DE9C73900311DBF /* GitHubExplorerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitHubExplorerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A24E3A1F2DE9C73600311DBF /* GitHubExplorer */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = GitHubExplorer;
+			sourceTree = "<group>";
+		};
+		A24E3A2D2DE9C73900311DBF /* GitHubExplorerTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = GitHubExplorerTests;
+			sourceTree = "<group>";
+		};
+		A24E3A372DE9C73900311DBF /* GitHubExplorerUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = GitHubExplorerUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A24E3A1A2DE9C73500311DBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A24E3A272DE9C73900311DBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A24E3A312DE9C73900311DBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A24E3A142DE9C73500311DBF = {
+			isa = PBXGroup;
+			children = (
+				A24E3A1F2DE9C73600311DBF /* GitHubExplorer */,
+				A24E3A2D2DE9C73900311DBF /* GitHubExplorerTests */,
+				A24E3A372DE9C73900311DBF /* GitHubExplorerUITests */,
+				A24E3A1E2DE9C73500311DBF /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A24E3A1E2DE9C73500311DBF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A24E3A1D2DE9C73500311DBF /* GitHubExplorer.app */,
+				A24E3A2A2DE9C73900311DBF /* GitHubExplorerTests.xctest */,
+				A24E3A342DE9C73900311DBF /* GitHubExplorerUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A24E3A1C2DE9C73500311DBF /* GitHubExplorer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A24E3A3E2DE9C73900311DBF /* Build configuration list for PBXNativeTarget "GitHubExplorer" */;
+			buildPhases = (
+				A24E3A192DE9C73500311DBF /* Sources */,
+				A24E3A1A2DE9C73500311DBF /* Frameworks */,
+				A24E3A1B2DE9C73500311DBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A24E3A1F2DE9C73600311DBF /* GitHubExplorer */,
+			);
+			name = GitHubExplorer;
+			packageProductDependencies = (
+			);
+			productName = GitHubExplorer;
+			productReference = A24E3A1D2DE9C73500311DBF /* GitHubExplorer.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A24E3A292DE9C73900311DBF /* GitHubExplorerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A24E3A412DE9C73900311DBF /* Build configuration list for PBXNativeTarget "GitHubExplorerTests" */;
+			buildPhases = (
+				A24E3A262DE9C73900311DBF /* Sources */,
+				A24E3A272DE9C73900311DBF /* Frameworks */,
+				A24E3A282DE9C73900311DBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A24E3A2C2DE9C73900311DBF /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A24E3A2D2DE9C73900311DBF /* GitHubExplorerTests */,
+			);
+			name = GitHubExplorerTests;
+			packageProductDependencies = (
+			);
+			productName = GitHubExplorerTests;
+			productReference = A24E3A2A2DE9C73900311DBF /* GitHubExplorerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		A24E3A332DE9C73900311DBF /* GitHubExplorerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A24E3A442DE9C73900311DBF /* Build configuration list for PBXNativeTarget "GitHubExplorerUITests" */;
+			buildPhases = (
+				A24E3A302DE9C73900311DBF /* Sources */,
+				A24E3A312DE9C73900311DBF /* Frameworks */,
+				A24E3A322DE9C73900311DBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A24E3A362DE9C73900311DBF /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A24E3A372DE9C73900311DBF /* GitHubExplorerUITests */,
+			);
+			name = GitHubExplorerUITests;
+			packageProductDependencies = (
+			);
+			productName = GitHubExplorerUITests;
+			productReference = A24E3A342DE9C73900311DBF /* GitHubExplorerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A24E3A152DE9C73500311DBF /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1640;
+				LastUpgradeCheck = 1640;
+				TargetAttributes = {
+					A24E3A1C2DE9C73500311DBF = {
+						CreatedOnToolsVersion = 16.4;
+					};
+					A24E3A292DE9C73900311DBF = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = A24E3A1C2DE9C73500311DBF;
+					};
+					A24E3A332DE9C73900311DBF = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = A24E3A1C2DE9C73500311DBF;
+					};
+				};
+			};
+			buildConfigurationList = A24E3A182DE9C73500311DBF /* Build configuration list for PBXProject "GitHubExplorer" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A24E3A142DE9C73500311DBF;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A24E3A1E2DE9C73500311DBF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A24E3A1C2DE9C73500311DBF /* GitHubExplorer */,
+				A24E3A292DE9C73900311DBF /* GitHubExplorerTests */,
+				A24E3A332DE9C73900311DBF /* GitHubExplorerUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A24E3A1B2DE9C73500311DBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A24E3A282DE9C73900311DBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A24E3A322DE9C73900311DBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A24E3A192DE9C73500311DBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A24E3A262DE9C73900311DBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A24E3A302DE9C73900311DBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A24E3A2C2DE9C73900311DBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A24E3A1C2DE9C73500311DBF /* GitHubExplorer */;
+			targetProxy = A24E3A2B2DE9C73900311DBF /* PBXContainerItemProxy */;
+		};
+		A24E3A362DE9C73900311DBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A24E3A1C2DE9C73500311DBF /* GitHubExplorer */;
+			targetProxy = A24E3A352DE9C73900311DBF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A24E3A3C2DE9C73900311DBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A24E3A3D2DE9C73900311DBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A24E3A3F2DE9C73900311DBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftpublished.dev.GitHubExplorer;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A24E3A402DE9C73900311DBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftpublished.dev.GitHubExplorer;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A24E3A422DE9C73900311DBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftpublished.dev.GitHubExplorerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GitHubExplorer.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/GitHubExplorer";
+			};
+			name = Debug;
+		};
+		A24E3A432DE9C73900311DBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftpublished.dev.GitHubExplorerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GitHubExplorer.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/GitHubExplorer";
+			};
+			name = Release;
+		};
+		A24E3A452DE9C73900311DBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftpublished.dev.GitHubExplorerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = GitHubExplorer;
+			};
+			name = Debug;
+		};
+		A24E3A462DE9C73900311DBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftpublished.dev.GitHubExplorerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = GitHubExplorer;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A24E3A182DE9C73500311DBF /* Build configuration list for PBXProject "GitHubExplorer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A24E3A3C2DE9C73900311DBF /* Debug */,
+				A24E3A3D2DE9C73900311DBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A24E3A3E2DE9C73900311DBF /* Build configuration list for PBXNativeTarget "GitHubExplorer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A24E3A3F2DE9C73900311DBF /* Debug */,
+				A24E3A402DE9C73900311DBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A24E3A412DE9C73900311DBF /* Build configuration list for PBXNativeTarget "GitHubExplorerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A24E3A422DE9C73900311DBF /* Debug */,
+				A24E3A432DE9C73900311DBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A24E3A442DE9C73900311DBF /* Build configuration list for PBXNativeTarget "GitHubExplorerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A24E3A452DE9C73900311DBF /* Debug */,
+				A24E3A462DE9C73900311DBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A24E3A152DE9C73500311DBF /* Project object */;
+}

--- a/GitHubExplorer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/GitHubExplorer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/GitHubExplorer/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/GitHubExplorer/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GitHubExplorer/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/GitHubExplorer/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GitHubExplorer/Assets.xcassets/Contents.json
+++ b/GitHubExplorer/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GitHubExplorer/ContentView.swift
+++ b/GitHubExplorer/ContentView.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = UserSearchViewModel(
+        gitHubService: GitHubService()
+    )
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                // Search section
+                VStack(spacing: 12) {
+                    TextField("Enter GitHub username", text: $viewModel.searchText)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .onSubmit {
+                            viewModel.searchUser()
+                        }
+
+                    Button("Search") {
+                        viewModel.searchUser()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.searchText.isEmpty || viewModel.isLoading)
+                }
+                .padding(.horizontal)
+
+                // Content section
+                if viewModel.isLoading {
+                    ProgressView("Searching...")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let user = viewModel.user {
+                    ScrollView {
+                        VStack(spacing: 16) {
+                            // Avatar
+                            AsyncImage(url: URL(string: user.avatarURL)) { image in
+                                image
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                            } placeholder: {
+                                RoundedRectangle(cornerRadius: 50)
+                                    .fill(Color.gray.opacity(0.3))
+                            }
+                            .frame(width: 100, height: 100)
+                            .clipShape(Circle())
+
+                            VStack(spacing: 8) {
+                                Text(user.name ?? user.login)
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+
+                                Text("@\(user.login)")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+
+                                if let bio = user.bio {
+                                    Text(bio)
+                                        .font(.body)
+                                        .multilineTextAlignment(.center)
+                                        .padding(.horizontal)
+                                }
+                            }
+
+                            // Stats
+                            HStack(spacing: 20) {
+                                VStack(spacing: 4) {
+                                    Text("\(user.publicRepos)")
+                                        .font(.title2)
+                                        .fontWeight(.bold)
+                                    Text("Repos")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                VStack(spacing: 4) {
+                                    Text("\(user.followers)")
+                                        .font(.title2)
+                                        .fontWeight(.bold)
+                                    Text("Followers")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                VStack(spacing: 4) {
+                                    Text("\(user.following)")
+                                        .font(.title2)
+                                        .fontWeight(.bold)
+                                    Text("Following")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                            .padding(.top)
+                        }
+                        .padding()
+                    }
+                } else if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    Text("Enter a GitHub username to search")
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+
+                Spacer()
+            }
+            .navigationTitle("GitHub Explorer")
+        }
+    }
+}
+
+/// View for displaying user details
+private struct UserDetailView: View {
+    let user: GitHubUser
+
+    var body: some View {
+
+    }
+}
+
+/// View for displaying a stat with title and value
+private struct StatView: View {
+    let title: String
+    let value: Int
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("\(value)")
+                .font(.title2)
+                .fontWeight(.bold)
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/GitHubExplorer/GitHubExplorerApp.swift
+++ b/GitHubExplorer/GitHubExplorerApp.swift
@@ -1,0 +1,17 @@
+//
+//  GitHubExplorerApp.swift
+//  GitHubExplorer
+//
+//  Created by kanagasabapathy on 30.05.25.
+//
+
+import SwiftUI
+
+@main
+struct GitHubExplorerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/GitHubExplorer/Models/GitHubUser.swift
+++ b/GitHubExplorer/Models/GitHubUser.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Represents a GitHub user from the API
+struct GitHubUser: Codable, Identifiable, Equatable {
+    let id: Int
+    let login: String
+    let avatarURL: String
+    let htmlURL: String
+    let name: String?
+    let bio: String?
+    let publicRepos: Int
+    let followers: Int
+    let following: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case id, login, name, bio, followers, following
+        case avatarURL = "avatar_url"
+        case htmlURL = "html_url"
+        case publicRepos = "public_repos"
+    }
+}

--- a/GitHubExplorer/README.md
+++ b/GitHubExplorer/README.md
@@ -1,0 +1,120 @@
+# GitHub Explorer
+
+A SwiftUI iOS application for searching GitHub users, built with modern Swift concurrency and MVVM architecture.
+
+## 🚨 IMPORTANT: Bad Code Practices Branch
+
+**Current Branch: `bad-code-practices`**
+
+This branch contains **INTENTIONALLY BAD CODE** for educational purposes and junior developer training. The code demonstrates common anti-patterns and problematic practices that should be avoided in production.
+
+**Note**: All obvious "BAD" comments have been removed to simulate realistic junior developer code that needs to be reviewed.
+
+### 🔴 Bad Practices Implemented (FOR TRAINING ONLY):
+
+#### 1. **Missing `weak self` - Retain Cycles**
+- Timer callbacks without `[weak self]` capture lists
+- Async closures capturing `self` strongly
+- **Impact**: Memory leaks, objects never deallocated
+
+#### 2. **Force Unwrapping**
+- URL creation: `URL(string: u.avatarURL)!`
+- Multiple force unwraps: `text!.first!`
+- Network parsing: `try! JSONSerialization.jsonObject(with: data!)`
+- **Impact**: App crashes when nil values encountered
+
+#### 3. **Poor Variable Naming**
+- Single letter variables: `t`, `u`, `l`, `e`, `gs`, `st`
+- Unclear abbreviations and poor naming conventions
+- Global variables: `g`, `isAppRunning`, `π`
+- **Impact**: Code becomes unreadable and unmaintainable
+
+#### 4. **Memory Leaks**
+- Timers never invalidated (commented out cleanup)
+- Strong reference cycles in closures
+- **Impact**: Memory usage grows until app crash
+
+#### 5. **Magic Numbers**
+- Hard-coded values: `42`, `3.14159`, `1000`, `100`
+- No constants or meaningful names
+- **Impact**: Hard to maintain and understand
+
+#### 6. **Global State & Singletons**
+- Mutable global variables throughout
+- Overuse of singletons with public mutable state
+- **Impact**: Unpredictable behavior, hard to test
+
+#### 7. **Boolean Traps**
+- Functions with multiple boolean parameters
+- `doSomething(_ flag: Bool, _ other: Bool, _ third: Bool)`
+- **Impact**: Confusing API, easy to make mistakes
+
+#### 8. **Functions Doing Too Much**
+- Single functions handling multiple responsibilities
+- Mixed concerns (network, file, UI, math operations)
+- **Impact**: Hard to test, debug, and maintain
+
+#### 9. **Poor Error Handling**
+- Using `try!` instead of proper error handling
+- Force casting: `response as! HTTPURLResponse`
+- **Impact**: App crashes instead of graceful error handling
+
+#### 10. **Side Effects in Wrong Places**
+- Heavy work in initializers
+- Side effects in computed properties
+- Modifying global state unexpectedly
+- **Impact**: Unpredictable performance and behavior
+
+### 🎯 Training Exercise Ideas:
+
+1. **Code Review Session**: Have junior developers identify all the problems
+2. **Refactoring Challenge**: Fix one category of issues at a time
+3. **Memory Profiling**: Use Instruments to see the memory leaks in action
+4. **Crash Testing**: Run the app and trigger crashes with bad data
+5. **Performance Analysis**: Measure the impact of bad practices
+
+### 🔧 How to Test Bad Practices:
+
+1. Tap "Timer" button multiple times → Creates memory leaks
+2. Tap "Callback" button → Triggers retain cycles
+3. Search for users → Force unwrapping may crash with bad data
+4. Leave app running → Memory usage will grow from leaks
+
+### ✅ Clean Version:
+
+Switch to `main` branch to see the properly implemented version with:
+- Proper memory management with `[weak self]`
+- Safe optional handling instead of force unwrapping
+- Clear, descriptive variable names
+- Proper error handling
+- Clean architecture
+- Modern Swift patterns
+
+## Project Structure
+
+```
+GitHubExplorer/
+├── Models/
+│   └── GitHubUser.swift
+├── Services/
+│   ├── Protocols/
+│   │   └── GitHubServiceProtocol.swift
+│   └── GitHubService.swift
+├── ViewModels/
+│   └── UserSearchViewModel.swift (⚠️ PROBLEMATIC CODE)
+├── Utils/
+│   └── BadUtilities.swift (⚠️ VERY PROBLEMATIC CODE)
+└── ContentView.swift (⚠️ PROBLEMATIC CODE)
+```
+
+## Technical Stack
+
+- **Language**: Swift 5.9+
+- **Framework**: SwiftUI
+- **Architecture**: MVVM (poorly implemented)
+- **Concurrency**: async/await (with memory issues)
+- **Dependency Management**: SPM
+
+---
+
+**⚠️ WARNING**: This code is for educational purposes only. The issues are subtle and realistic - exactly what you'd see in real junior developer code!

--- a/GitHubExplorer/Services/GitHubService.swift
+++ b/GitHubExplorer/Services/GitHubService.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Concrete implementation of GitHub API service
+final class GitHubService: GitHubServiceProtocol {
+    private let session: URLSession
+    private let baseURL = "https://api.github.com"
+
+    /// Initializes the service with a URLSession
+    /// - Parameter session: URLSession to use for network requests
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    /// Searches for a GitHub user by username using modern Swift concurrency
+    /// - Parameter username: The GitHub username to search for
+    /// - Returns: A GitHubUser if found
+    /// - Throws: NetworkError or other errors that may occur during the request
+    func searchUser(username: String) async throws -> GitHubUser {
+        guard let url = URL(string: "\(baseURL)/users/\(username)") else {
+            throw NetworkError.invalidURL
+        }
+
+        do {
+            let (data, response) = try await session.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw NetworkError.invalidResponse
+            }
+
+            switch httpResponse.statusCode {
+            case 200:
+                break
+            case 404:
+                throw NetworkError.userNotFound
+            default:
+                throw NetworkError.invalidResponse
+            }
+
+            guard !data.isEmpty else {
+                throw NetworkError.noData
+            }
+
+            do {
+                let user = try JSONDecoder().decode(GitHubUser.self, from: data)
+                return user
+            } catch {
+                throw NetworkError.decodingError
+            }
+        } catch let error as NetworkError {
+            throw error
+        } catch {
+            throw NetworkError.invalidResponse
+        }
+    }
+}

--- a/GitHubExplorer/Services/Protocols/GitHubServiceProtocol.swift
+++ b/GitHubExplorer/Services/Protocols/GitHubServiceProtocol.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Protocol defining GitHub API operations
+protocol GitHubServiceProtocol {
+    /// Searches for a GitHub user by username
+    /// - Parameter username: The GitHub username to search for
+    /// - Returns: A GitHubUser if found
+    /// - Throws: NetworkError or other errors that may occur during the request
+    func searchUser(username: String) async throws -> GitHubUser
+}
+
+/// Errors that can occur during network operations
+enum NetworkError: Error, LocalizedError {
+    case invalidURL
+    case noData
+    case userNotFound
+    case invalidResponse
+    case decodingError
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL"
+        case .noData:
+            return "No data received"
+        case .userNotFound:
+            return "User not found"
+        case .invalidResponse:
+            return "Invalid response"
+        case .decodingError:
+            return "Failed to decode response"
+        }
+    }
+}

--- a/GitHubExplorer/Utils/NetworkUtilities.swift
+++ b/GitHubExplorer/Utils/NetworkUtilities.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+var g = ""
+var isAppRunning = true
+let π = 3.14159
+
+class NetworkUtilities {
+
+    static let shared = NetworkUtilities()
+
+    var temp = ""
+    var count = 0
+    var items: [String] = []
+
+    var timer: Timer?
+
+    private init() {
+        for i in 0..<1000 {
+            temp += "x"
+        }
+
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            self.count += 1
+            print("Timer: \(self.count)")
+        }
+    }
+
+    func doSomething(_ flag: Bool, _ other: Bool, _ third: Bool) {
+        if flag && other && third {
+            print("All true")
+        }
+    }
+
+    func urlStringProcessing(_ text: String?) -> String {
+        let t = text!
+        let firstChar = t.first!
+        let url = URL(string: "https://example.com")!
+
+        return String(firstChar) + url.absoluteString
+    }
+
+    func urlSessionTaskFunction() {
+        let url = URL(string: "https://api.github.com")!
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            let httpResponse = response as! HTTPURLResponse
+            let statusCode = httpResponse.statusCode
+
+            if statusCode == 200 {
+                let jsonData = data!
+                let json = try! JSONSerialization.jsonObject(with: jsonData)
+                print(json)
+            }
+        }
+        task.resume()
+
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+        let filePath = documentsPath + "/file.txt"
+        try! "Some data".write(to: URL(fileURLWithPath: filePath), atomically: true, encoding: .utf8)
+
+        for i in 0..<100 {
+            let result = Double(i) * π
+            if result > 42 {
+                g += String(result)
+            }
+        }
+
+        var numbers = [1, 2, 3, 4, 5]
+        numbers.removeLast()
+        numbers.removeLast()
+        let lastNumber = numbers.last!
+        print("Last: \(lastNumber)")
+    }
+
+    func createLeakyClosures() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.temp = "updated"
+            self.performAsyncWork()
+        }
+
+        DispatchQueue.global().async {
+            self.count += 1
+            print("Count: \(self.count)")
+        }
+    }
+
+    private func performAsyncWork() {
+        DispatchQueue.global().async {
+            for i in 0..<10000 {
+                self.temp += String(i)
+            }
+
+            DispatchQueue.main.async {
+                self.items.append(self.temp)
+            }
+        }
+    }
+
+    deinit {
+        // timer?.invalidate()
+        print("NetworkUtilities deinit - but timer is still running!")
+    }
+}
+
+extension String {
+    var processedOutput: String {
+        NetworkUtilities.shared.count += 1
+        g += self
+
+        let url = URL(string: "https://example.com")!
+        return self + url.absoluteString
+    }
+}
+
+func f(_ s: String) -> String {
+    g = s
+    isAppRunning = false
+    return s.uppercased()
+}
+
+func someNetworkCall(completion: @escaping (String) -> Void) {
+    let url = URL(string: "https://jsonplaceholder.typicode.com/posts/1")!
+
+    URLSession.shared.dataTask(with: url) { data, response, error in
+        let json = try! JSONSerialization.jsonObject(with: data!) as! [String: Any]
+        let title = json["title"] as! String
+
+        completion(title)
+    }.resume()
+}

--- a/GitHubExplorer/ViewModels/UserSearchViewModel.swift
+++ b/GitHubExplorer/ViewModels/UserSearchViewModel.swift
@@ -1,0 +1,61 @@
+import Foundation
+import SwiftUI
+
+/// ViewModel for user search functionality
+@MainActor
+final class UserSearchViewModel: ObservableObject {
+    // MARK: - Published Properties
+    @Published var searchText = ""
+    @Published var user: GitHubUser?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    // MARK: - Private Properties
+    private let gitHubService: GitHubServiceProtocol
+    private var searchTask: Task<Void, Never>?
+
+    // MARK: - Initialization
+    init(gitHubService: GitHubServiceProtocol) {
+        self.gitHubService = gitHubService
+    }
+
+    // MARK: - Public Methods
+    func searchUser() {
+        let trimmedText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmedText.isEmpty {
+            user = nil
+            errorMessage = nil
+            searchTask?.cancel()
+            return
+        }
+
+        searchTask?.cancel()
+
+        searchTask = Task {
+            isLoading = true
+            errorMessage = nil
+
+            do {
+                let foundUser = try await gitHubService.searchUser(username: trimmedText)
+                user = foundUser
+                errorMessage = nil
+            } catch {
+                user = nil
+                errorMessage = error.localizedDescription
+            }
+
+            isLoading = false
+        }
+    }
+
+    func clearResults() {
+        user = nil
+        errorMessage = nil
+        searchTask?.cancel()
+    }
+
+    deinit {
+        searchTask?.cancel()
+    }
+}

--- a/GitHubExplorerTests/GitHubExplorerTests.swift
+++ b/GitHubExplorerTests/GitHubExplorerTests.swift
@@ -1,0 +1,17 @@
+//
+//  GitHubExplorerTests.swift
+//  GitHubExplorerTests
+//
+//  Created by kanagasabapathy on 30.05.25.
+//
+
+import Testing
+@testable import GitHubExplorer
+
+struct GitHubExplorerTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/GitHubExplorerUITests/GitHubExplorerUITests.swift
+++ b/GitHubExplorerUITests/GitHubExplorerUITests.swift
@@ -1,0 +1,41 @@
+//
+//  GitHubExplorerUITests.swift
+//  GitHubExplorerUITests
+//
+//  Created by kanagasabapathy on 30.05.25.
+//
+
+import XCTest
+
+final class GitHubExplorerUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/GitHubExplorerUITests/GitHubExplorerUITestsLaunchTests.swift
+++ b/GitHubExplorerUITests/GitHubExplorerUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  GitHubExplorerUITestsLaunchTests.swift
+//  GitHubExplorerUITests
+//
+//  Created by kanagasabapathy on 30.05.25.
+//
+
+import XCTest
+
+final class GitHubExplorerUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
This pull request introduces a new SwiftUI-based iOS application, "GitHub Explorer," designed for searching GitHub users. It includes the app's foundational structure, key features, and intentionally bad coding practices for educational purposes. Below is a summary of the most important changes grouped by theme.

### Core Application Features

* Added `GitHubExplorerApp.swift` to define the app's entry point, using `ContentView` as the main view.
* Implemented `ContentView.swift`, which provides the main user interface for searching GitHub users, displaying user details, and handling loading/error states.
* Created `GitHubUser.swift` to model GitHub user data with properties like `id`, `login`, `avatarURL`, and `followers`, conforming to `Codable` and `Identifiable`.

### Networking and ViewModel

* Added `GitHubService.swift` as the concrete implementation of `GitHubServiceProtocol` for interacting with the GitHub API, including error handling via a `NetworkError` enum. [[1]](diffhunk://#diff-9151128b69ce54148b16ae23688bb5d8dbc735918c43dc753e1de5a1864144c7R1-R55) [[2]](diffhunk://#diff-869b6860a466001ccc6e958fe22a909224db49f9f4c6764513b8de5fce44b614R1-R34)
* Introduced `UserSearchViewModel.swift`, which manages user search logic, integrates with `GitHubService`, and updates the UI state using `@Published` properties.

### Educational Focus: Bad Practices

* Added a detailed `README.md` outlining intentionally bad coding practices (e.g., retain cycles, force unwrapping, poor naming conventions) for training junior developers.
* Created `NetworkUtilities.swift` to demonstrate problematic patterns such as memory leaks, global state, and force unwrapping, for educational purposes.

### Assets and Testing

* Added app assets, including `AccentColor.colorset` and `AppIcon.appiconset`, for visual branding. [[1]](diffhunk://#diff-903a0cf11e160dbca0ffe402baa99170e96d981bd977271f025bbefda57d419aR1-R11) [[2]](diffhunk://#diff-c7750d7158dd6db3cb18189b421a7cc215dab97c79167ad843dddfc9ce1d6477R1-R35)
* Introduced placeholder test files for unit and UI testing (`GitHubExplorerTests.swift` and `GitHubExplorerUITests.swift`). [[1]](diffhunk://#diff-e564a580db165f47c9eb4833b632fa12fd10d79d8779523231c7f9706c546a0bR1-R17) [[2]](diffhunk://#diff-69ec8ad07f60c9e881be6f865a727d3bc51c32c71334e56178195182cf36e4b4R1-R41)